### PR TITLE
explanation on configuring branch name for 'Improve this page' button

### DIFF
--- a/content/posts/configuration/site-parameters/index.md
+++ b/content/posts/configuration/site-parameters/index.md
@@ -72,6 +72,12 @@ gitRepo: <your site's Github repo URL>
 
 This will add a button labeled `Improve This Page` at the bottom of every blog post. The button will route the user directly to the respective edit page in Github.
 
+If your default branch isn't called `main` then you need to add your git default branch in the `params` section of your `config.yaml` file.
+
+```yaml
+gitBranch: <your git default branch name>
+```
+
 ### Enable/Disable Newsletter
 
 The newsletter feature only supports Mailchimp for now.  


### PR DESCRIPTION
I've added an explanation of what to do when your git default branch isn't called `main`. I noticed that my 'Improve this page' button wasn't working because of this, and after looking at the single.html page I noticed that I could change this with the `gitBranch` option