### PR TITLE
Replace all config.yaml occurrences to hugo.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -230,7 +230,7 @@ params:
     # To disable Hugo's builtin syntax highlight,
     # see: https://gohugo.io/getting-started/configuration-markup#highlight
     # ```
-    # # config.yaml
+    # # hugo.yaml
     # markup:
     #   # this disables hugo's syntax highlighting.
     #   codeFences: false

--- a/content/posts/analytics/index.es.md
+++ b/content/posts/analytics/index.es.md
@@ -22,7 +22,7 @@ Este tema tiene soporte para varias herramientas de analíticas. Actualmente, so
 - [Matomo](https://matomo.org/)
 - [Umami](https://umami.is/)
 
-Para una lista completa de las analíticas soportadas, puede consultar el archivo de ejemplo [config.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/config.yaml).
+Para una lista completa de las analíticas soportadas, puede consultar el archivo de ejemplo [hugo.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/hugo.yaml).
 
 {{< alert type="warning" >}}
 Advertencia: Al añadir analíticas, debe considerar la legislación local para ver si se requiere un banner de privacidad para informar a los usuarios sobre el seguimiento de los datos personales. En general (no asesoramiento legal), los métodos anónimos y respetuosos de la privacidad, como [counter.dev](https://counter.dev) y [GoatCounter](https://www.goatcounter.com/), no necesitan un banner, ya que no recopilan datos de identificación personal.
@@ -32,7 +32,7 @@ Advertencia: Al añadir analíticas, debe considerar la legislación local para 
 
 [GoatCounter](https://www.goatcounter.com/) son las analíticas que soporta Toha más completas, simples y respetuosas con la privacidad. Su script rastrea las páginas más vistas, el número total de usuarios, dispositivos y mucho más, ¡todo mientras es de código abierto!
 
-Para habilitar las analíticas de GoatCounter en tu sitio, tienes dos opciones: acceder a [goatcounter.com](https://www.goatcounter.com) y obtener un código para tu sitio web, y el segundo es self-hostear una instancia de GoatCounter. Después, tienes que añadir la sección `analytics` debajo de la sección `params.features` de tu archivo `config.yaml`, como a continuación:
+Para habilitar las analíticas de GoatCounter en tu sitio, tienes dos opciones: acceder a [goatcounter.com](https://www.goatcounter.com) y obtener un código para tu sitio web, y el segundo es self-hostear una instancia de GoatCounter. Después, tienes que añadir la sección `analytics` debajo de la sección `params.features` de tu archivo `hugo.yaml`, como a continuación:
 
 ```yaml
 analytics:
@@ -48,7 +48,7 @@ analytics:
 
 [counter.dev](https://counter.dev) es un sitio web de análisis de código abierto, sencillo y respetuoso con la privacidad que le permite realizar un seguimiento del recuento total de usuarios, la primera página visitada y algunas otras métricas de su sitio web. Desafortunadamente, para simplificar las cosas (y gratis), no muestran una clasificación de las páginas más visitadas, sino de aquellas a las que se accede primero.
 
-Puedes habilitarlo añadiendo el email que te has registrado a la página de counter.dev debajo de la sección `params.features` de tu archivo `config.yaml`, como a continuación:
+Puedes habilitarlo añadiendo el email que te has registrado a la página de counter.dev debajo de la sección `params.features` de tu archivo `hugo.yaml`, como a continuación:
 
 ```yaml
 analytics:
@@ -70,7 +70,7 @@ Nota: En algunos sitios, aparece [an error has been detected](https://github.com
 Tenga en cuenta que, según la [jurisprudencia reciente](https://www.euractiv.com/section/politics/short_news/use-of-google-analytics-violates-eu-law-austrian-authority-rules/), Google Analytics podría ser ilegal en la Unión Europea
 {{< /alert >}}
 
-Puedes habilitar Google Analytics en tu sitio añadiendo tu id de rastreo debajo de la sección `params.features` de tu archivo `config.yaml`, como a continuación:
+Puedes habilitar Google Analytics en tu sitio añadiendo tu id de rastreo debajo de la sección `params.features` de tu archivo `hugo.yaml`, como a continuación:
 
 ```yaml
 analytics:
@@ -83,11 +83,11 @@ analytics:
 
 Puede utilizar el ID de seguimiento tanto V3 como V4. El tema detectará automáticamente la versión de seguimiento, y añadirá los scripts respectivos de acuerdo a tu sitio web.
 
-Para configuraciones de privacidad adicionales de Google Analytics, puedes proveer la sección `privacy.googleAnalytics` dentro del archivo `config.yaml` descrito [aquí](https://gohugo.io/about/hugo-and-gdpr/#all-privacy-settings).
+Para configuraciones de privacidad adicionales de Google Analytics, puedes proveer la sección `privacy.googleAnalytics` dentro del archivo `hugo.yaml` descrito [aquí](https://gohugo.io/about/hugo-and-gdpr/#all-privacy-settings).
 
 ### Matomo
 
-Puedes habilitar Matomo (antes Piwik) en tu sitio añadiendo tu configuración de matomo debajo de la sección `params.features` de tu archivo `config.yaml`, como a continuación:
+Puedes habilitar Matomo (antes Piwik) en tu sitio añadiendo tu configuración de matomo debajo de la sección `params.features` de tu archivo `hugo.yaml`, como a continuación:
 
 ```yaml
 analytics:
@@ -102,7 +102,7 @@ analytics:
 
 [Umami](https://umami.is) es una herramienta de analíticas de código abierto totalmente compatible con GDPR y con un enfoque sin cookies. Puede instalarse localmente o puede utilizar la versión en la nube proporcionada.
 
-Puedes habilitar el seguimiento de Umami añadiendo la siguiente configuración en la sección `params.features` de tu archivo `config.yaml`:
+Puedes habilitar el seguimiento de Umami añadiendo la siguiente configuración en la sección `params.features` de tu archivo `hugo.yaml`:
 
 ```yaml
 analytics:

--- a/content/posts/analytics/index.fr.md
+++ b/content/posts/analytics/index.fr.md
@@ -22,7 +22,7 @@ Ce thème a été construit avec le support de divers outils d'analyse. Actuelle
 - [Matomo](https://matomo.org/)
 - [Umami](https://umami.is/)
 
-Pour une liste complète des analytiques supportés, référez-vous au fichier d'échantillon [config.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/config.yaml).
+Pour une liste complète des analytiques supportés, référez-vous au fichier d'échantillon [hugo.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/hugo.yaml).
 
 {{< alert type="warning" >}}
 Avertissement: Lors de l'ajout d'analyses, vous devriez prendre en considération la législation locale pour voir si une bannière de confidentialité est nécessaire pour informer les visiteurs du suivi de ses données personnelles. En général (pas un conseil juridique), les méthodes anonymes et respectueuses de la vie privée telles que [counter.dev](https://counter.dev) et [GoatCounter](https://www.goatcounter.com/) n'ont pas besoin d'une bannière, car elles ne collectent pas de données personnelles identifiables.
@@ -32,7 +32,7 @@ Avertissement: Lors de l'ajout d'analyses, vous devriez prendre en considératio
 
 [GoatCounter](https://www.goatcounter.com/) est la méthode d'analyse la plus complète, simple et respectueuse de la vie privée supportée dans Toha. Ces scripts traquent les pages les plus vues, le nombre total d'utilisateur, et plus encore, tout en étant open source !
 
-Pour activer l'analyse GoatCounter sur votre site, vous avez deux options: la première est de s'inscrire sur [goatcounter.com](https://www.goatcounter.com) et obtenir un code pour votre site, la seconde est une instance auto-hébergée de GoatCounter. Ensuite, vous avez à ajouter une section `analytics` sous la section `params.features` de votre fichier `config.yaml` comme ci-dessous:
+Pour activer l'analyse GoatCounter sur votre site, vous avez deux options: la première est de s'inscrire sur [goatcounter.com](https://www.goatcounter.com) et obtenir un code pour votre site, la seconde est une instance auto-hébergée de GoatCounter. Ensuite, vous avez à ajouter une section `analytics` sous la section `params.features` de votre fichier `hugo.yaml` comme ci-dessous:
 
 ```yaml
 analytics:
@@ -48,7 +48,7 @@ analytics:
 
 [counter.dev](https://counter.dev) est un site d'analytique simple et respectueux de la vie privée qui vous permet de suivre le nombre total d'utilisateurs, la première page visitée et quelques autres métriques sur votre site web. Malheureusement, pour que les choses restent simples (et gratuites), elles ne montrent pas un classement des pages les plus visités, mais plutôt celles qui ont été consultées en premier.
 
-Vous pouvez l'activer par l'ajout de l'email avec lequel vous vous êtes inscrit sur la page de counter.dev sous la section `params.features` dans votre fichier `config.yaml` comme ci-dessous:
+Vous pouvez l'activer par l'ajout de l'email avec lequel vous vous êtes inscrit sur la page de counter.dev sous la section `params.features` dans votre fichier `hugo.yaml` comme ci-dessous:
 
 ```yaml
 analytics:
@@ -69,7 +69,7 @@ Remarques : Sur certains sites, [une erreur a été détectée](https://github.c
 Méfiez-vous, [d'après une récente jurisprudence](https://www.euractiv.com/section/politics/short_news/use-of-google-analytics-violates-eu-law-austrian-authority-rules/), Google Analytics pourrait être illégal dans l'Union Européenne.
 {{< /alert >}}
 
-Vous pouvez activer Google Analytics sur votre site en ajoutant votre id de suivi sous la section `params.features` dans votre fichier `config.yaml` comme ci-dessous:
+Vous pouvez activer Google Analytics sur votre site en ajoutant votre id de suivi sous la section `params.features` dans votre fichier `hugo.yaml` comme ci-dessous:
 
 ```yaml
 analytics:
@@ -82,11 +82,11 @@ analytics:
 
 Vous pouvez utiliser à la fois la V3 ou V4 de l'ID de suivi. Le thème détectera automatiquement la version du code de suivi et ajoutera les scripts de suivi correspondants en fonction de votre site.
 
-Pour des paramètres de confidentialité additionnels concernant Google Analytics, vous pouvez fournir une section `privacy.googleAnalytics` dans votre fichier `config.yaml` comme décrit [ici](https://gohugo.io/about/hugo-and-gdpr/#all-privacy-settings).
+Pour des paramètres de confidentialité additionnels concernant Google Analytics, vous pouvez fournir une section `privacy.googleAnalytics` dans votre fichier `hugo.yaml` comme décrit [ici](https://gohugo.io/about/hugo-and-gdpr/#all-privacy-settings).
 
 ### Matomo
 
-Vous pouvez activer Matomo (anciennement Piwik) par l'ajout de la configuration Matomo sous la section `params.features` dans votre fichier `config.yaml` comme ci-dessous:
+Vous pouvez activer Matomo (anciennement Piwik) par l'ajout de la configuration Matomo sous la section `params.features` dans votre fichier `hugo.yaml` comme ci-dessous:
 
 ```yaml
 analytics:
@@ -100,7 +100,7 @@ analytics:
 
 ### Umami
 
-[Umami](https://umami.is) est un outil d'analyse open source en total conformité avec le <abbr title="Règlement Général sur la Protection des Données">RGPD</abbr> avec une approche sans cookies. Il peut être installé sur site ou vous pouvez utiliser la version Cloud fournie. Vous pouvez activer le suivi d'Umami en ajoutant les configurations suivantes sous `params.features` section dans le fichier `config.yaml`:
+[Umami](https://umami.is) est un outil d'analyse open source en total conformité avec le <abbr title="Règlement Général sur la Protection des Données">RGPD</abbr> avec une approche sans cookies. Il peut être installé sur site ou vous pouvez utiliser la version Cloud fournie. Vous pouvez activer le suivi d'Umami en ajoutant les configurations suivantes sous `params.features` section dans le fichier `hugo.yaml`:
 
 ```yaml
 analytics:

--- a/content/posts/analytics/index.md
+++ b/content/posts/analytics/index.md
@@ -19,7 +19,7 @@ This theme has built in support for various analytic tools. Currently, it suppor
 - [Matomo](https://matomo.org/)
 - [Umami](https://umami.is/)
 
-For a complete list of supported analytics, please refer the sample [config.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/config.yaml) file.
+For a complete list of supported analytics, please refer the sample [hugo.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/hugo.yaml) file.
 
 {{< alert type="warning" >}}
 Warning: When adding analytics, you should consider local legislation to see if a privacy banner is required to inform users of the tracking in personal data. In general (not legal advice), privacy-friendly, anonymous methods such as [counter.dev](https://counter.dev) and [GoatCounter](https://www.goatcounter.com/) don't need a banner, since they do not collect personally identifiable data.
@@ -29,7 +29,7 @@ Warning: When adding analytics, you should consider local legislation to see if 
 
 [GoatCounter](https://www.goatcounter.com/) is the most complete, simple and privacy friendly analytics method supported in Toha. Its script tracks the most viewed pages, total number of users, devices, and much more, all while being open source!
 
-To enable GoatCounter analytics in your site, you have two options: one is to sign in at [goatcounter.com](https://www.goatcounter.com) and obtain a code for your site, the second is to self-hosted an instance of GoatCounter. Then, you have to add `analytics` section under `params.features` section of your `config.yaml` file as below:
+To enable GoatCounter analytics in your site, you have two options: one is to sign in at [goatcounter.com](https://www.goatcounter.com) and obtain a code for your site, the second is to self-hosted an instance of GoatCounter. Then, you have to add `analytics` section under `params.features` section of your `hugo.yaml` file as below:
 
 ```yaml
 analytics:
@@ -45,7 +45,7 @@ analytics:
 
 [counter.dev](https://counter.dev) is a simple, privacy friendly and open source analytics website which enables you to track the total user count, first visited page and some other metrics on your website. Unfortunately, to keep things simple (and free) they don't show a ranking of the most visited pages, but rather the ones that are accessed the first.
 
-You can enable it by adding the email you registered with at counter.dev's page under `params.features` section in your `config.yaml` as below:
+You can enable it by adding the email you registered with at counter.dev's page under `params.features` section in your `hugo.yaml` as below:
 
 ```yaml
 analytics:
@@ -67,7 +67,7 @@ Note: On some sites, [an error has been detected](https://github.com/ihucos/coun
 Beware that [according to recent case law](https://www.euractiv.com/section/politics/short_news/use-of-google-analytics-violates-eu-law-austrian-authority-rules/), Google Analytics might be illegal in the European Union
 {{< /alert >}}
 
-You can enable Google Analytics in your site by adding your tracking id under `params.features` section in your `config.yaml` file as below:
+You can enable Google Analytics in your site by adding your tracking id under `params.features` section in your `hugo.yaml` file as below:
 
 ```yaml
 analytics:
@@ -80,11 +80,11 @@ analytics:
 
 You can use both V3 or V4 tracking ID. The theme will automatically detect the tracking code version and add the respective tracking scripts accordingly to your site.
 
-For additional privacy settings regarding Google Analytics, you can provide `privacy.googleAnalytics` section in your `config.yaml` file as described [here](https://gohugo.io/about/hugo-and-gdpr/#all-privacy-settings).
+For additional privacy settings regarding Google Analytics, you can provide `privacy.googleAnalytics` section in your `hugo.yaml` file as described [here](https://gohugo.io/about/hugo-and-gdpr/#all-privacy-settings).
 
 ### Matomo
 
-You can enable Matomo (formerly Piwik) by adding the matomo configuration under `params.features` section in the `config.yaml` file as shown below:
+You can enable Matomo (formerly Piwik) by adding the matomo configuration under `params.features` section in the `hugo.yaml` file as shown below:
 
 ```yaml
 analytics:
@@ -99,7 +99,7 @@ analytics:
 ### Umami
 
 [Umami](https://umami.is) is an open source analytics tool fully compliant with <abbr title="General Data Protection Regulation">GDPR</abbr> and with a cookieless approach. It can be installed on-premise or you can use the provided cloud version.
-You can enable the Umami tracking by adding the following configs under `params.features` section in the `config.yaml` file:
+You can enable the Umami tracking by adding the following configs under `params.features` section in the `hugo.yaml` file:
 
 ```yaml
 analytics:

--- a/content/posts/comments/index.es.md
+++ b/content/posts/comments/index.es.md
@@ -20,11 +20,11 @@ Este tema tiene soporte para comentarios en las publicaciones. Actualmente, sopo
 - [Utterances](https://utteranc.es/)
 - [Giscus](https://giscus.app/)
 
-Para una lista completa de las extensiones de comentarios soportadas, puede consultar el archivo de ejemplo [config.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/config.yaml).
+Para una lista completa de las extensiones de comentarios soportadas, puede consultar el archivo de ejemplo [hugo.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/hugo.yaml).
 
 ### Disqus
 
-Disqus es una extensión de comentarios popular. Después de acceder a [Disqus](https://disqus.com/) necesitarás proveer tu shortname debajo de la sección `params.features` de tu archivo `config.yaml`, como a continuación:
+Disqus es una extensión de comentarios popular. Después de acceder a [Disqus](https://disqus.com/) necesitarás proveer tu shortname debajo de la sección `params.features` de tu archivo `hugo.yaml`, como a continuación:
 
 ```yaml
 comment:
@@ -36,7 +36,7 @@ comment:
 
 ### Valine
 
-[Valine](https://valine.js.org/) resulta ser una extensión de comentarios chino. Puedes habilitar la extensión de comentarios valine añadiendo la sección `valine` debajo de la sección `params.features` de tu archivo `config.yaml`, como a continuación: 
+[Valine](https://valine.js.org/) resulta ser una extensión de comentarios chino. Puedes habilitar la extensión de comentarios valine añadiendo la sección `valine` debajo de la sección `params.features` de tu archivo `hugo.yaml`, como a continuación: 
 
 ```yaml
 comment:
@@ -54,7 +54,7 @@ comment:
 
 ### Utterances
 
-Para habilitar la extensión de comentarios Utterances, necesitarás ir primero a [utteranc.es](https://utteranc.es/). En la sección de `Configuration`, provee la información necesaria. Te dará un script para incluir en tu sitio. Solo necesitarás extraer la información respectiva del script, y proveerla debajo de la sección `params.features` de tu archivo `config.yaml`, como a continuación: 
+Para habilitar la extensión de comentarios Utterances, necesitarás ir primero a [utteranc.es](https://utteranc.es/). En la sección de `Configuration`, provee la información necesaria. Te dará un script para incluir en tu sitio. Solo necesitarás extraer la información respectiva del script, y proveerla debajo de la sección `params.features` de tu archivo `hugo.yaml`, como a continuación: 
 
 ```yaml
 comment:
@@ -70,7 +70,7 @@ comment:
 
 Giscus está basado en Utterances, pero usa [GitHub Discussions](https://docs.github.com/en/discussions) como backend. Esto requiere tener un repositorio público, y permitir que la aplicación Giscus use tu repositorio. Las instrucciones de configuración se pueden encontrar en [Giscus home page](https://giscus.app/).
 
-Para habilitar la extensión de comentarios Utterances, necesitarás ir primero a [giscus.app](https://giscus.app/). En la sección de `Configuration`, provee la información necesaria. Te dará un script para incluir en tu sitio. Solo necesitarás extraer la información respectiva del script, y proveerla debajo de la sección `params.features` de tu archivo `config.yaml`, como a continuación: 
+Para habilitar la extensión de comentarios Utterances, necesitarás ir primero a [giscus.app](https://giscus.app/). En la sección de `Configuration`, provee la información necesaria. Te dará un script para incluir en tu sitio. Solo necesitarás extraer la información respectiva del script, y proveerla debajo de la sección `params.features` de tu archivo `hugo.yaml`, como a continuación: 
 
 ```yaml
 comment:

--- a/content/posts/comments/index.fr.md
+++ b/content/posts/comments/index.fr.md
@@ -19,7 +19,7 @@ Ce thème supporte les commentaires dans les billets. Actuellement, il supporte 
 
 ### Disqus
 
-Disqus est un plugin de commentaires très populaire. Après vous êtes inscrit sur [Disqus](https://disqus.com/) vous aurez besoin de fournir votre pseudonyme sous la section `params.features.comment` de votre fichier `config.yaml` comme ci-après:
+Disqus est un plugin de commentaires très populaire. Après vous êtes inscrit sur [Disqus](https://disqus.com/) vous aurez besoin de fournir votre pseudonyme sous la section `params.features.comment` de votre fichier `hugo.yaml` comme ci-après:
 
 ```yaml
 params:
@@ -32,7 +32,7 @@ params:
 
 ### Valine
 
-[Valine](https://valine.js.org/) semble être un plugin de commentaires chinois. Vous pouvez activer le plugin de commentaires `valine` en ajoutant une section `valine` sous `params.features.comments` de votre fichier `config.yaml` comme ci-après:
+[Valine](https://valine.js.org/) semble être un plugin de commentaires chinois. Vous pouvez activer le plugin de commentaires `valine` en ajoutant une section `valine` sous `params.features.comments` de votre fichier `hugo.yaml` comme ci-après:
 
 ```yaml
 params:

--- a/content/posts/comments/index.md
+++ b/content/posts/comments/index.md
@@ -17,11 +17,11 @@ This theme has built-in support for comment on the posts. Currently, it support 
 - [Utterances](https://utteranc.es/)
 - [Giscus](https://giscus.app/)
 
-For a complete list of supported comments, please refer the sample [config.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/config.yaml) file.
+For a complete list of supported comments, please refer the sample [hugo.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/hugo.yaml) file.
 
 ### Disqus
 
-Disqus is a popular comment plug-in. After signing up to [Disqus](https://disqus.com/) you will need to provide your shortname under `params.features` section of your `config.yaml` file as below:
+Disqus is a popular comment plug-in. After signing up to [Disqus](https://disqus.com/) you will need to provide your shortname under `params.features` section of your `hugo.yaml` file as below:
 
 ```yaml
 comment:

--- a/content/posts/configuration/site-parameters/index.es.md
+++ b/content/posts/configuration/site-parameters/index.es.md
@@ -20,7 +20,7 @@ Para obtener una lista completa de los parámetros de configuración disponibles
 
 ### Añade un Fondo
 
-Para empezar, vamos a establecer un fondo para tu sitio web. Pon la imagen de fondo que desee en el directorio `assets/images`. Después, añade lo siguiente en la sección `params` del archivo `config.yaml`.
+Para empezar, vamos a establecer un fondo para tu sitio web. Pon la imagen de fondo que desee en el directorio `assets/images`. Después, añade lo siguiente en la sección `params` del archivo `hugo.yaml`.
 
 ```yaml
 background: "images/nombre_de_tu_imagen_de_fondo.jpg"
@@ -28,7 +28,7 @@ background: "images/nombre_de_tu_imagen_de_fondo.jpg"
 
 ### Añade un Logo
 
-Para añadir logos para tu sitio, necesitas dos logos diferentes: uno para la barra de navegación transparente, y otro para la barra de navegación no-transparente. Pon tus logos dentro del directorio `assets/images` y añade las siguientes líneas debajo de la sección `params` del archivo `config.yaml`.
+Para añadir logos para tu sitio, necesitas dos logos diferentes: uno para la barra de navegación transparente, y otro para la barra de navegación no-transparente. Pon tus logos dentro del directorio `assets/images` y añade las siguientes líneas debajo de la sección `params` del archivo `hugo.yaml`.
 
 ```yaml
 # El logo invertido será usado para la barra de navegación transparente.
@@ -41,7 +41,7 @@ logo:
 
 ### Habilita publicaciones del Blog
 
-Para habilitar publicaciones de blog en tu sitio web, necesitarás aplicar unos cambios en el archivo `config.yaml`. Localiza la sección `params.features` y añada el siguiente código.
+Para habilitar publicaciones de blog en tu sitio web, necesitarás aplicar unos cambios en el archivo `hugo.yaml`. Localiza la sección `params.features` y añada el siguiente código.
 
 ```yaml
 # Habilita y configura publicaciones de Blog
@@ -52,14 +52,14 @@ blog:
 
 ### Habilita `Tabla de Contenido`
 
-Ahora, si quiere mostrar la sección `Tabla de Contenido` en tu publicación de blog, tienes que habilitarlo en la sección `params.features` del archivo `config.yaml`.
+Ahora, si quiere mostrar la sección `Tabla de Contenido` en tu publicación de blog, tienes que habilitarlo en la sección `params.features` del archivo `hugo.yaml`.
 
 ```yaml
 toc:
   enable: true
 ```
 
-También puedes controlar los niveles de tu Tabla de Contenido añadiendo la siguiente configuración en la sección de `markup` de tu archivo `config.yaml`.
+También puedes controlar los niveles de tu Tabla de Contenido añadiendo la siguiente configuración en la sección de `markup` de tu archivo `hugo.yaml`.
 
 ```yaml
 markup:
@@ -73,7 +73,7 @@ Aquí, hemos configurado nuestra Tabla de Contenido para mostrar todos los encab
 
 ### Habilita el botón `<Mejorar esta página>`
 
-Si quieres permitir que los lectores mejoren fácilmente una publicación haciendo correcciones como faltas de ortografía o identación, puedes habilitar el botón `<Mejorar esta página>`. Para hacerlo, añada su URL del repositorio de git en la sección `params` del archivo `config.yaml`.
+Si quieres permitir que los lectores mejoren fácilmente una publicación haciendo correcciones como faltas de ortografía o identación, puedes habilitar el botón `<Mejorar esta página>`. Para hacerlo, añada su URL del repositorio de git en la sección `params` del archivo `hugo.yaml`.
 
 ```yaml
 gitRepo: <URL de tu repositorio de Github del sitio>
@@ -81,7 +81,7 @@ gitRepo: <URL de tu repositorio de Github del sitio>
 
 Esto añadirá un botón con la etiqueta `Mejorar esta página` al final de cada publicación de blog. El botón dirigirá al usuario directamente a la página de edición respectiva en Github.
 
-Si tu rama por defecto no tiene el nombre de `main`, necesitarás especificar tu rama por defecto de git en la sección `params` en el archivo `config.yaml`.
+Si tu rama por defecto no tiene el nombre de `main`, necesitarás especificar tu rama por defecto de git en la sección `params` en el archivo `hugo.yaml`.
 
 ```yaml
 gitBranch: <nombre de tu rama por defecto de git>
@@ -89,7 +89,7 @@ gitBranch: <nombre de tu rama por defecto de git>
 
 ### Habilita Boletín Informativo
 
-Para habilitar la funcionalidad de boletín informativo, necesitarás proveer los parámetros necesarios debajo de la sección `params.footer` en el archivo `config.yaml`. Ahora mismo, el boletín informativo solo es soportado por el proveedor Mailchimp. Aquí hay un ejemplo de cómo debería ser:
+Para habilitar la funcionalidad de boletín informativo, necesitarás proveer los parámetros necesarios debajo de la sección `params.footer` en el archivo `hugo.yaml`. Ahora mismo, el boletín informativo solo es soportado por el proveedor Mailchimp. Aquí hay un ejemplo de cómo debería ser:
 
 ```yaml
 newsletter:
@@ -107,7 +107,7 @@ newsletter:
 
 ### Habilita RAW HTML en los archivos de Markdown
 
-Si quiere incluir RAW HTML en tus archivos de markdown, necesitarás habilitar el rendering inseguro. Sin habilitarlo, Hugo no podrá renderizar HTML. Para habilitar rendering inseguro de markdown, añade la siguiente configuración de `goldmark` en la sección `markup` del archivo `config.yaml`.
+Si quiere incluir RAW HTML en tus archivos de markdown, necesitarás habilitar el rendering inseguro. Sin habilitarlo, Hugo no podrá renderizar HTML. Para habilitar rendering inseguro de markdown, añade la siguiente configuración de `goldmark` en la sección `markup` del archivo `hugo.yaml`.
 
 ```yaml
 markup:

--- a/content/posts/configuration/site-parameters/index.fr.md
+++ b/content/posts/configuration/site-parameters/index.fr.md
@@ -17,7 +17,7 @@ Pour une liste compréhensive des paramètres de configuration disponibles, cons
 
 ### Ajouter une image d'arrière plan
 
-D'abord, on va paramètrer un arrière plan sur votre site. Mettez l'image d'arrière plan désirée dans le répertoire `assets/images`. Ensuite, ajoutez ce qui suit dans la section `params` de votre fichier `config.yaml`.
+D'abord, on va paramètrer un arrière plan sur votre site. Mettez l'image d'arrière plan désirée dans le répertoire `assets/images`. Ensuite, ajoutez ce qui suit dans la section `params` de votre fichier `hugo.yaml`.
 
 ```yaml
 background: "images/<nom-de-votre-image-arrière-plan.jpg"
@@ -25,7 +25,7 @@ background: "images/<nom-de-votre-image-arrière-plan.jpg"
 
 ### Ajouter le logo du site
 
-Pour ajouter des logos pour votre site, vous devez fournir deux logos différents. Un pour la barre de navigation transparente et un autre pour la barre de navigation non transparente. Placez vos logos dans le répertoire `assets/images` et ajoutez le code sous la section `params` du fichier `config.yaml`.
+Pour ajouter des logos pour votre site, vous devez fournir deux logos différents. Un pour la barre de navigation transparente et un autre pour la barre de navigation non transparente. Placez vos logos dans le répertoire `assets/images` et ajoutez le code sous la section `params` du fichier `hugo.yaml`.
 
 ```yaml
 # The inverted logo will be used in the initial transparent navbar and
@@ -38,7 +38,7 @@ logo:
 
 ### Activer les billets de blog
 
-Pour activer les billets de blog sur votre site, vous aurez besoin de faire quelques changements dans votre fichier `config.yaml`. Localisez la section `params.features` et ajoutez le code suivant:
+Pour activer les billets de blog sur votre site, vous aurez besoin de faire quelques changements dans votre fichier `hugo.yaml`. Localisez la section `params.features` et ajoutez le code suivant:
 
 ```yaml
 # Active et configure la publication de billets
@@ -49,13 +49,13 @@ blog:
 
 ### Activer la `Table des Matières`
 
-Maintenant, si vous voulez afficher la section `Table des Matières` dans votre billet de blog, vous devez d'abord l'activer dans la section `params.features` de votre fichier `config.yaml`.
+Maintenant, si vous voulez afficher la section `Table des Matières` dans votre billet de blog, vous devez d'abord l'activer dans la section `params.features` de votre fichier `hugo.yaml`.
 
 ```yaml
 toc:
   enable: true
 ```
-Vous pouvez également contrôler le niveau de votre table des matières par l'ajout de la configuration suivante dans la section `markup` de votre fichier `config.yaml`.
+Vous pouvez également contrôler le niveau de votre table des matières par l'ajout de la configuration suivante dans la section `markup` de votre fichier `hugo.yaml`.
 
 ```yaml
 markup:
@@ -69,7 +69,7 @@ Ici, nous avons configuré notre table des matières pour afficher tous les titr
 
 ### Activer le bouton `<Améliorer cette page>`
 
-Si vous voulez fournir à vos visiteurs un moyen facile d'améliorer un article (par exemple une faute de frappe, un correctif d'indentation, etc.), vous pouvez activer le bouton `<Améliorer cette page>` en ajoutant l'URL de votre dépôt Git dans la section `params` de votre fichier `config.yaml`.
+Si vous voulez fournir à vos visiteurs un moyen facile d'améliorer un article (par exemple une faute de frappe, un correctif d'indentation, etc.), vous pouvez activer le bouton `<Améliorer cette page>` en ajoutant l'URL de votre dépôt Git dans la section `params` de votre fichier `hugo.yaml`.
 
 ```yaml
 gitRepo: <L'URL du dépôt Github de votre site>
@@ -77,7 +77,7 @@ gitRepo: <L'URL du dépôt Github de votre site>
 
 Cela ajoutera un bouton labelisé `Améliorer cette page` au pied de chaque billet. Le bouton redirigera l'utilisateur directement vers le formulaire d'édition de Github de la page.
 
-Si vous branche par défaut ne s'appelle pas `main`, alors vous aurez besoin d'ajouter votre branche git par défaut dans la section `params` de votre fichier `config.yaml`.
+Si vous branche par défaut ne s'appelle pas `main`, alors vous aurez besoin d'ajouter votre branche git par défaut dans la section `params` de votre fichier `hugo.yaml`.
 
 ```yaml
 gitBranch: <le nom de votre branche git par défaut>
@@ -85,7 +85,7 @@ gitBranch: <le nom de votre branche git par défaut>
 
 ### Activer la Newsletter
 
-Pour activer la fonctionnalité de newsletter, vous avez besoin de fournir les paramètres nécessaires sous la section `params.footer` dans votre fichier `config.yaml`. Actuellement, la fonctionnalité de newsletter supporte seulement le service Mailchip. Ici un exemple de ce à quoi cela doit ressembler:
+Pour activer la fonctionnalité de newsletter, vous avez besoin de fournir les paramètres nécessaires sous la section `params.footer` dans votre fichier `hugo.yaml`. Actuellement, la fonctionnalité de newsletter supporte seulement le service Mailchip. Ici un exemple de ce à quoi cela doit ressembler:
 
 ```yaml
 newsletter:
@@ -103,7 +103,7 @@ newsletter:
 
 ### Activer le RAW HTML dans le fichier Markdown
 
-Si vous voulez inclure le RAW HTML dans vos fichiers markdown, vous avez besoin d'activer le rendu non sécurisé. Sans cette activation, Hugo n'affichera pas le rendu HTML. Pour activer le rendu markdown non sécurisé; ajoutez les paramètres `goldmark` suivants dans la section `markup` du fichier `config.yaml`.
+Si vous voulez inclure le RAW HTML dans vos fichiers markdown, vous avez besoin d'activer le rendu non sécurisé. Sans cette activation, Hugo n'affichera pas le rendu HTML. Pour activer le rendu markdown non sécurisé; ajoutez les paramètres `goldmark` suivants dans la section `markup` du fichier `hugo.yaml`.
 
 ```yaml
 markup:

--- a/content/posts/configuration/site-parameters/index.md
+++ b/content/posts/configuration/site-parameters/index.md
@@ -17,7 +17,7 @@ For a comprehensive list of available configuration parameters, please refer to 
 
 ### Add Background Image
 
-At first, let's set a background on your website. Put your desired background image in the `assets/images` directory. Then add the following in the `params` section of your `config.yaml` file.
+At first, let's set a background on your website. Put your desired background image in the `assets/images` directory. Then add the following in the `params` section of your `hugo.yaml` file.
 
 ```yaml
 background: "images/name-of-your-background-image.jpg"
@@ -25,7 +25,7 @@ background: "images/name-of-your-background-image.jpg"
 
 ### Add Site's Logo
 
-To add logos for your site, you need two different logos: one for the transparent navbar and another for the non-transparent navbar. Place your logos in the `assets/images` directory and add the following code under the `params` section of your `config.yaml` file.
+To add logos for your site, you need two different logos: one for the transparent navbar and another for the non-transparent navbar. Place your logos in the `assets/images` directory and add the following code under the `params` section of your `hugo.yaml` file.
 
 ```yaml
 # The inverted logo will be used in the initial transparent navbar and
@@ -38,7 +38,7 @@ logo:
 
 ### Enable Blog Post
 
-To enable blog posting on your site, you need to make some changes in the `config.yaml` file. Locate the `params.features` section and add the following code:
+To enable blog posting on your site, you need to make some changes in the `hugo.yaml` file. Locate the `params.features` section and add the following code:
 
 ```yaml
 # Enable and configure blog posts
@@ -49,14 +49,14 @@ blog:
 
 ### Enable `Table Of Contents`
 
-Now, if you want to show `Table Of Contents` section in your blog post, you have to enable it in the `params.features` section of `config.yaml` file.
+Now, if you want to show `Table Of Contents` section in your blog post, you have to enable it in the `params.features` section of `hugo.yaml` file.
 
 ```yaml
 toc:
   enable: true
 ```
 
-You can also control the level of your TOC by adding the following configuration in the `markup` section of your `config.yaml` file.
+You can also control the level of your TOC by adding the following configuration in the `markup` section of your `hugo.yaml` file.
 
 ```yaml
 markup:
@@ -70,7 +70,7 @@ Here, we have configured our TOC to show all headings from `h2` to `h6`.
 
 ### Enable `<Improve This Page>` Button
 
-If you want to allow readers to easily improve a post by making corrections such as fixing typos or indentation, you can enable the `<Improve This Page>` button. To do this, add your git repository URL in the `params` section of your `config.yaml` file.
+If you want to allow readers to easily improve a post by making corrections such as fixing typos or indentation, you can enable the `<Improve This Page>` button. To do this, add your git repository URL in the `params` section of your `hugo.yaml` file.
 
 ```yaml
 gitRepo: <your site's Github repo URL>
@@ -78,7 +78,7 @@ gitRepo: <your site's Github repo URL>
 
 This will add a button labeled `Improve This Page` at the bottom of every blog post. The button will route the user directly to the respective edit page in Github.
 
-If your default branch is not named `main`, you need to specify your git default branch in the `params` section of your `config.yaml` file.
+If your default branch is not named `main`, you need to specify your git default branch in the `params` section of your `hugo.yaml` file.
 
 ```yaml
 gitBranch: <your git default branch name>
@@ -86,7 +86,7 @@ gitBranch: <your git default branch name>
 
 ### Enable Newsletter
 
-To enable the newsletter feature, you need to provide the necessary parameters under the `params.footer` section in your `config.yaml` file. Currently, the newsletter feature only supports the Mailchimp provider. Here is an example of how it should look:
+To enable the newsletter feature, you need to provide the necessary parameters under the `params.footer` section in your `hugo.yaml` file. Currently, the newsletter feature only supports the Mailchimp provider. Here is an example of how it should look:
 
 ```yaml
 newsletter:
@@ -104,7 +104,7 @@ newsletter:
 
 ### Enable RAW HTML in the Markdown File
 
-If you want to include RAW HTML in your markdown files, you need to enable unsafe rendering. Without enabling this, Hugo will not render the HTML. To enable unsafe markdown rendering, add the following `goldmark` settings to the `markup` section of your `config.yaml` file.
+If you want to include RAW HTML in your markdown files, you need to enable unsafe rendering. Without enabling this, Hugo will not render the HTML. To enable unsafe markdown rendering, add the following `goldmark` settings to the `markup` section of your `hugo.yaml` file.
 
 ```yaml
 markup:

--- a/content/posts/contributing/index.es.md
+++ b/content/posts/contributing/index.es.md
@@ -69,7 +69,7 @@ $ npm install
 $ hugo server -w
 ```
 
-Ahora, puedes hacer cambios en el tema, y se verán reflectados inmediatamente en el sitio. Si necesitas cambiar alguna configuración, lo puedes hacer en el archivo `config.yaml` dentro del directorio `exampleSite`. Si necesitas añadir contenido o datos, puedes crear el respectivo directorio dentro de `exampleSite` y añade tu contenido o datos deseados ahí.
+Ahora, puedes hacer cambios en el tema, y se verán reflectados inmediatamente en el sitio. Si necesitas cambiar alguna configuración, lo puedes hacer en el archivo `hugo.yaml` dentro del directorio `exampleSite`. Si necesitas añadir contenido o datos, puedes crear el respectivo directorio dentro de `exampleSite` y añade tu contenido o datos deseados ahí.
 
 #### Ejecuta el tema forkeado con tu propio sitio
 

--- a/content/posts/contributing/index.fr.md
+++ b/content/posts/contributing/index.fr.md
@@ -68,7 +68,7 @@ $ npm install
 $ hugo server -w
 ```
 
-Maintenant, vous pouvez faire des changements dans le thème et ils seront immédiatement restitués sur le site en cours d'exécution. Si vous avez besoin de changer n'importe quelle configuration, vous pouvez faire cela dans le fichier `config.yaml` à l'intérieur du répertoire `exampleSite`. Si vous avez besoin d'ajouter n'importe quel contenu ou donnée, vous pouvez créer le dossier correspondant à l'intérieur du répertoire `exampleSite` et ajouter votre contenu ou donnée désirés.
+Maintenant, vous pouvez faire des changements dans le thème et ils seront immédiatement restitués sur le site en cours d'exécution. Si vous avez besoin de changer n'importe quelle configuration, vous pouvez faire cela dans le fichier `hugo.yaml` à l'intérieur du répertoire `exampleSite`. Si vous avez besoin d'ajouter n'importe quel contenu ou donnée, vous pouvez créer le dossier correspondant à l'intérieur du répertoire `exampleSite` et ajouter votre contenu ou donnée désirés.
 
 #### Lancer le thème cloné par rapport à votre propre site
 

--- a/content/posts/contributing/index.md
+++ b/content/posts/contributing/index.md
@@ -68,7 +68,7 @@ $ npm install
 $ hugo server -w
 ```
 
-Now, you can make change in the theme and they will be reflected immediately on the running site. If you need to change any configuration, you can do that in the `config.yaml` file inside `exampleSite` folder. If you need to add any content or data, you can create the respective folder inside `exampleSite` directory and add your desired content or data there.
+Now, you can make change in the theme and they will be reflected immediately on the running site. If you need to change any configuration, you can do that in the `hugo.yaml` file inside `exampleSite` folder. If you need to add any content or data, you can create the respective folder inside `exampleSite` directory and add your desired content or data there.
 
 #### Running the forked theme against your own site
 

--- a/content/posts/customizing/dark-theme/index.es.md
+++ b/content/posts/customizing/dark-theme/index.es.md
@@ -12,7 +12,7 @@ menu:
     weight: 405
 ---
 
-Para habilitar el modo oscuro en Toha `v4.0.0`, simplemente establece el campo `darkMode.enable` a `true` debajo de la sección `params.features` dentro del archivo `config.yaml`. Por ejemplo:
+Para habilitar el modo oscuro en Toha `v4.0.0`, simplemente establece el campo `darkMode.enable` a `true` debajo de la sección `params.features` dentro del archivo `hugo.yaml`. Por ejemplo:
 
 ```yaml
 params:

--- a/content/posts/customizing/dark-theme/index.fr.md
+++ b/content/posts/customizing/dark-theme/index.fr.md
@@ -16,7 +16,7 @@ menu:
 
 Toha `v3.6.0` a introduit un thème sombre. Un grand merci à [@donfiguerres](https://github.com/donfiguerres). Ce guide vous montrera comment l'activer.
 
-Tout d'abord, assurez-vous d'avoir mis à jour la version du thème en `v3.6.0` ou plus. Ensuite, ajoutez la section suivante sous la section `params` de votre fichier `config.yaml`.
+Tout d'abord, assurez-vous d'avoir mis à jour la version du thème en `v3.6.0` ou plus. Ensuite, ajoutez la section suivante sous la section `params` de votre fichier `hugo.yaml`.
 
 ```yaml
   darkMode:

--- a/content/posts/customizing/dark-theme/index.md
+++ b/content/posts/customizing/dark-theme/index.md
@@ -12,7 +12,7 @@ menu:
     weight: 405
 ---
 
-To enable the dark mode in Toha `v4.0.0`, simply set the `darkMode.enable` field to `true` under the `params.features` section in your `config.yaml` file. For example:
+To enable the dark mode in Toha `v4.0.0`, simply set the `darkMode.enable` field to `true` under the `params.features` section in your `hugo.yaml` file. For example:
 
 ```yaml
 params:

--- a/content/posts/getting-started/prepare-site/index.fr.md
+++ b/content/posts/getting-started/prepare-site/index.fr.md
@@ -163,7 +163,7 @@ params:
     enable: true
 ```
 
-Ici, vous voyez une configuration de base pour le thème Toha. Vous pouvez voir le fichier de configuration utilisé dans le site d'exemple [ici](https://github.com/hugo-toha/hugo-toha.github.io/blob/source/config.yaml). Pour des options de configurations plus détaillées, s'il vous plaît consultez [ce billet](https://toha-guides.netlify.app/posts/configuration/site-parameters/).
+Ici, vous voyez une configuration de base pour le thème Toha. Vous pouvez voir le fichier de configuration utilisé dans le site d'exemple [ici](https://github.com/hugo-toha/hugo-toha.github.io/blob/source/hugo.yaml). Pour des options de configurations plus détaillées, s'il vous plaît consultez [ce billet](https://toha-guides.netlify.app/posts/configuration/site-parameters/).
 
 #### Ajouter des données
 

--- a/content/posts/quickstart/index.es.md
+++ b/content/posts/quickstart/index.es.md
@@ -68,9 +68,9 @@ Deberías ver los archivos `go.mod` y `go.sum` en la raíz de su repositorio. Ac
 module github.com/<su usuario>/<nombre de su repositorio>
 ```
 
-#### Paso 4: Cambie el archivo `config.yaml`
+#### Paso 4: Cambie el archivo `hugo.yaml`
 
-Ahora, abre el repositorio en un editor y, cambie las siguientes configuraciones en tu archivo `config.yaml` localizado en la raíz de su repositorio.
+Ahora, abre el repositorio en un editor y, cambie las siguientes configuraciones en tu archivo `hugo.yaml` localizado en la raíz de su repositorio.
 
 ##### Cambia la `baseURL`
 

--- a/content/posts/quickstart/index.fr.md
+++ b/content/posts/quickstart/index.fr.md
@@ -65,9 +65,9 @@ Vous devriez voir les fichiers `go.mod` et `go.sum` à la racine du dépôt. Met
 module github.com/<votre username>/<nom du dépôt forké>
 ```
 
-#### Etape 4: Modifier le fichier `config.yaml`
+#### Etape 4: Modifier le fichier `hugo.yaml`
 
-Maintenant, ouvrez le dépôt dans un éditeur et modifiez les configurations dans votre fichier `config.yaml` situé à la racine de votre dépôt.
+Maintenant, ouvrez le dépôt dans un éditeur et modifiez les configurations dans votre fichier `hugo.yaml` situé à la racine de votre dépôt.
 
 ##### Modifier le `baseURL`
 

--- a/content/posts/quickstart/index.md
+++ b/content/posts/quickstart/index.md
@@ -65,7 +65,7 @@ You should see `go.mod` and `go.sum` files in the root of the repository. Update
 module github.com/<your username>/<forked repo name>
 ```
 
-#### Step 4: Change `config.yaml` file
+#### Step 4: Change `hugo.yaml` file
 
 Now, open the repository in an editor and change the following configurations in your `hugo.yaml` file located at the root of your repository.
 

--- a/content/posts/supports/index.es.md
+++ b/content/posts/supports/index.es.md
@@ -17,11 +17,11 @@ Este tema soporta la adición de varios enlaces de soporte/donación en su sitio
 - [Ko-fi](https://ko-fi.com/)
 - [Buy Me a Coffee](https://www.buymeacoffee.com/zicklam)
 
-Para una lista completa de los enlaces de soporte admitidos, puede consultar el archivo de ejemplo [config.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/config.yaml).
+Para una lista completa de los enlaces de soporte admitidos, puede consultar el archivo de ejemplo [hugo.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/hugo.yaml).
 
 ## Ko-fi
 
-Puedes añadir tu botón flotante Ko-fi en tu sitio web. Para añadir el botón flotante, añade la sección `support` debajo de la sección `params.features`  del archivo `config.yaml`.
+Puedes añadir tu botón flotante Ko-fi en tu sitio web. Para añadir el botón flotante, añade la sección `support` debajo de la sección `params.features`  del archivo `hugo.yaml`.
 
 ```yaml
 support:
@@ -36,7 +36,7 @@ support:
 
 ## Buy Me a Coffee
 
-Puedes añadir tu botón flotante "Buy Me a Coffee" en tu sitio web. Para añadir el botón flotante, añade la sección `support` debajo de la sección `params.features`  del archivo `config.yaml`.
+Puedes añadir tu botón flotante "Buy Me a Coffee" en tu sitio web. Para añadir el botón flotante, añade la sección `support` debajo de la sección `params.features`  del archivo `hugo.yaml`.
 
 ![bmacbutton](https://git-doc-files.s3.eu-central-1.amazonaws.com/github.com/hugo-toha/guides/buymeacoffe-button.png)
 ![bmacwidget](https://git-doc-files.s3.eu-central-1.amazonaws.com/github.com/hugo-toha/guides/buymeacoffe-widget.png)

--- a/content/posts/supports/index.fr.md
+++ b/content/posts/supports/index.fr.md
@@ -16,7 +16,7 @@ Ce thème supporte l'ajout de liens de soutien/donation sur votre site. Actuelle
 
 ## Ko-fi
 
-Vous pouvez ajouter votre button flottant ko-fi sur votre site web. Pour ajouter le button flottant, ajoutez une section `support` sous la section `params.features` dans votre fichier `config.yaml`:
+Vous pouvez ajouter votre button flottant ko-fi sur votre site web. Pour ajouter le button flottant, ajoutez une section `support` sous la section `params.features` dans votre fichier `hugo.yaml`:
 
 ```yaml
 params:
@@ -32,7 +32,7 @@ params:
 
 ## Buy Me a Coffee
 
-Vous pouvez ajouter votre bouton flottant "Buy Me a Coffee" sur votre site web. Pour ajoutez une section `support` sous la section `params.features` dans votre fichier `config.yaml`:
+Vous pouvez ajouter votre bouton flottant "Buy Me a Coffee" sur votre site web. Pour ajoutez une section `support` sous la section `params.features` dans votre fichier `hugo.yaml`:
 
 ![bmacbutton](https://git-doc-files.s3.eu-central-1.amazonaws.com/github.com/hugo-toha/guides/buymeacoffe-button.png)
 ![bmacwidget](https://git-doc-files.s3.eu-central-1.amazonaws.com/github.com/hugo-toha/guides/buymeacoffe-widget.png)

--- a/content/posts/supports/index.md
+++ b/content/posts/supports/index.md
@@ -14,11 +14,11 @@ This theme supports adding various support/donation links in your site. Currentl
 - [Ko-fi](https://ko-fi.com/)
 - [Buy Me a Coffee](https://www.buymeacoffee.com/zicklam)
 
-For a complete list of supported support links, please refer the sample [config.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/config.yaml) file.
+For a complete list of supported support links, please refer the sample [hugo.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/hugo.yaml) file.
 
 ## Ko-fi
 
-You can add your Ko-fi floating button in your website. To add the floating button, add the `support` section under `params.features` section of your sites `config.yaml` file:
+You can add your Ko-fi floating button in your website. To add the floating button, add the `support` section under `params.features` section of your sites `hugo.yaml` file:
 
 ```yaml
 support:
@@ -33,7 +33,7 @@ support:
 
 ## Buy Me a Coffee
 
-You can add your "Buy Me a Coffee" floating button in your website. To add the floating button, add the `support` section under `params.features` section of your sites `config.yaml` file:
+You can add your "Buy Me a Coffee" floating button in your website. To add the floating button, add the `support` section under `params.features` section of your sites `hugo.yaml` file:
 
 ![bmacbutton](https://git-doc-files.s3.eu-central-1.amazonaws.com/github.com/hugo-toha/guides/buymeacoffe-button.png)
 ![bmacwidget](https://git-doc-files.s3.eu-central-1.amazonaws.com/github.com/hugo-toha/guides/buymeacoffe-widget.png)

--- a/content/posts/translation/new-language/index.es.md
+++ b/content/posts/translation/new-language/index.es.md
@@ -16,7 +16,7 @@ Si desea traducir a un idioma si soporte, puede traducir los elementos de la int
 
 ## Crea el archivo `i18n`
 
-Para haerlo, debes crear el directorio `i18n` dentro de la raíz del sitio, el directorio dónde puede encontrar el archivo `config.yaml`, y directorios como `data`, `content`, etc.
+Para haerlo, debes crear el directorio `i18n` dentro de la raíz del sitio, el directorio dónde puede encontrar el archivo `hugo.yaml`, y directorios como `data`, `content`, etc.
 
 Luego, puedes crear el archivo `<código_del_idioma>.toml` dentro del directorio `i18n`. En este [directorio](https://github.com/hugo-toha/hugo-toha.github.io/tree/gh-pages/flags/1x1) puedes encontrar todos los códigos de idiomas con las banderas que aparecerán junto a ese idioma.
 

--- a/content/posts/translation/new-language/index.fr.md
+++ b/content/posts/translation/new-language/index.fr.md
@@ -16,7 +16,7 @@ Si vous voulez traduire vers une langue non supportée, vous pouvez traduire les
 
 ## Créer un fichier `i18n`
 
-Pour ce faire, vous avez à créer un répertoire `i18n` à l'intérieur de la racine de votre site, le répertoire où vous pouvez trouver le fichier `config.yaml`, et les répertoires tel que `data`, `content`, etc.
+Pour ce faire, vous avez à créer un répertoire `i18n` à l'intérieur de la racine de votre site, le répertoire où vous pouvez trouver le fichier `hugo.yaml`, et les répertoires tel que `data`, `content`, etc.
 
 Après cela, vous pouvez créer le fichier `<langage code>.toml` dans le répertoire `i18n`. Dans ce [répertoire](https://github.com/hugo-toha/hugo-toha.github.io/tree/gh-pages/flags/1x1), vous pouvez trouver tous les codes de langue avec le drapeau qui apparaît avec ce code.
 

--- a/content/posts/translation/new-language/index.md
+++ b/content/posts/translation/new-language/index.md
@@ -16,7 +16,7 @@ If you want to translate to an unsupported language, you can translate the UI el
 
 ## Create an `i18n` file
 
-To do so, you have to create the `i18n` diretory inside the root of the site, the directory where you can find the `config.yaml` file, and directories like `data`, `content`, etc.
+To do so, you have to create the `i18n` diretory inside the root of the site, the directory where you can find the `hugo.yaml` file, and directories like `data`, `content`, etc.
 
 Afterwards, you can create the file `<language_code>.toml` into the `i18n` directory. In this [directory](https://github.com/hugo-toha/hugo-toha.github.io/tree/gh-pages/flags/1x1), you can find all language codes with the flag that will appear with that code.
 

--- a/content/posts/translation/site-data/index.es.md
+++ b/content/posts/translation/site-data/index.es.md
@@ -52,9 +52,9 @@ Para una lista completa de los idiomas soportados, por favor, consulte el archiv
 
 Si el idioma al que desea traducir el contenido no está disponible, consulte la guía [Cómo añadir un idioma sin soporte](/es/posts/translation/new-language/).
 
-### Añade el idioma a `config.yaml`
+### Añade el idioma a `hugo.yaml`
 
-Después de conocer el código para el idioma al que desea traducir su sitio, abra el archivo `config.yaml` y, debajo de la sección `language`, añade lo siguiente:
+Después de conocer el código para el idioma al que desea traducir su sitio, abra el archivo `hugo.yaml` y, debajo de la sección `language`, añade lo siguiente:
 
 ```yaml
 languages:

--- a/content/posts/translation/site-data/index.fr.md
+++ b/content/posts/translation/site-data/index.fr.md
@@ -52,9 +52,9 @@ Pour la liste complète des langages supportées, consultez s'il vous plaît le 
 
 Si la langue désirée pour la traduction du votre contenu n'est pas disponible, consultez s'il vous plaît le guide [Comment ajouter un langage non supporté ?](/fr/posts/translation/new-language/)
 
-### Ajouter la langue dans `config.yaml`
+### Ajouter la langue dans `hugo.yaml`
 
-Après avoir identifié le code de la langue pour laquelle vous voulez traduire votre site, ouvrez le fichier `config.yaml`, et sous la section `languages` ajoutez ce qui suit:
+Après avoir identifié le code de la langue pour laquelle vous voulez traduire votre site, ouvrez le fichier `hugo.yaml`, et sous la section `languages` ajoutez ce qui suit:
 
 ```yaml
 languages:

--- a/content/posts/translation/site-data/index.md
+++ b/content/posts/translation/site-data/index.md
@@ -52,9 +52,9 @@ For a complete list of the supported languages, please check the README file fro
 
 If the language you desire to translate the content to is not available, please check the guide [How to add an unsupported language](/posts/translation/new-language/).
 
-### Add the language into `config.yaml`
+### Add the language into `hugo.yaml`
 
-After you know what's the code for the language you wish to translate your site, open `config.yaml` file, and under the `languages` section add the following:
+After you know what's the code for the language you wish to translate your site, open `hugo.yaml` file, and under the `languages` section add the following:
 
 ```yaml
 languages:

--- a/content/posts/update-v3-to-v4/index.es.md
+++ b/content/posts/update-v3-to-v4/index.es.md
@@ -25,9 +25,9 @@ git rm themes/toha/
 git commit -m "Remove v3 theme"
 ```
 
-### 2. Borra `theme` de `config.yaml`
+### 2. Borra `theme` de `hugo.yaml`
 
-En la nueva versión, ya no necesitamos especificar `theme` en el archivo `config.yaml`. En cambio, necesitaremos añadir el tema como módulo. Por lo tanto, borra la siguiente línea del archivo `config.yaml`.
+En la nueva versión, ya no necesitamos especificar `theme` en el archivo `hugo.yaml`. En cambio, necesitaremos añadir el tema como módulo. Por lo tanto, borra la siguiente línea del archivo `hugo.yaml`.
 
 ```yaml
 theme: toha
@@ -55,7 +55,7 @@ Este comando creará un archivo `go.mod` a la raíz de su repositorio. Compruebe
 
 ### 5. Añade el tema como módulo
 
-Ahora, añade la siguiente sección `module` en el archivo `config.yaml`. Esto añadirá el tema como módulo y lo montará en los archivos estáticos del tema.
+Ahora, añade la siguiente sección `module` en el archivo `hugo.yaml`. Esto añadirá el tema como módulo y lo montará en los archivos estáticos del tema.
 
 ```yaml
 # Usa los modules de Hugo para añadir el tema
@@ -73,13 +73,13 @@ module:
     target: static/fonts
 ```
 
-### 6. Actualiza el archivo `config.yaml`
+### 6. Actualiza el archivo `hugo.yaml`
 
-En la nueva versión, la estructura de configuración de las funcionalidades ha sido restructurada. Asimismo, será necesario actualizar el archivo `config.yaml`. Como referencia, puede consultar el ejemplo del archivo [config.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/config.yaml). Aquí resaltaremos las configuraciones más comunes que necesitan cambiarse.
+En la nueva versión, la estructura de configuración de las funcionalidades ha sido restructurada. Asimismo, será necesario actualizar el archivo `hugo.yaml`. Como referencia, puede consultar el ejemplo del archivo [hugo.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/hugo.yaml). Aquí resaltaremos las configuraciones más comunes que necesitan cambiarse.
 
 **Modo oscuro:**
 
-Hemos introducido soporte para un nuevo modo oscuro. Como resultado, ya no necesitamos usar servicios de terceros como `darkreader`. Para habilitar el nuevo modo oscuro, por favor borra las siguientes líneas de tu archivo `config.yaml`:
+Hemos introducido soporte para un nuevo modo oscuro. Como resultado, ya no necesitamos usar servicios de terceros como `darkreader`. Para habilitar el nuevo modo oscuro, por favor borra las siguientes líneas de tu archivo `hugo.yaml`:
 
 ```yaml
  darkMode:
@@ -214,7 +214,7 @@ flags:
 
 ```
 
-Ha habido algunos otros cambios. Consulte el archivo de configuración de muestra [config.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/config.yaml) para obtener más detalles.
+Ha habido algunos otros cambios. Consulte el archivo de configuración de muestra [hugo.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/hugo.yaml) para obtener más detalles.
 
 ### 7. Ejecuta el sitio
 

--- a/content/posts/update-v3-to-v4/index.fr.md
+++ b/content/posts/update-v3-to-v4/index.fr.md
@@ -25,9 +25,9 @@ git rm themes/toha/
 git commit -m "Remove v3 theme"
 ```
 
-### 2. Supprimer le `theme` du `config.yaml`
+### 2. Supprimer le `theme` du `hugo.yaml`
 
-Dans cette nouvelle version, nous n'avons pas besoin de spécifier le `theme` dans le fichier `config.yaml`. A la place, nous ajouterons le thème comme un module. D'abord, supprimez la ligne suivante de votre fichier `config.yaml`:
+Dans cette nouvelle version, nous n'avons pas besoin de spécifier le `theme` dans le fichier `hugo.yaml`. A la place, nous ajouterons le thème comme un module. D'abord, supprimez la ligne suivante de votre fichier `hugo.yaml`:
 
 ```yaml
 theme: toha
@@ -55,7 +55,7 @@ Cela créera un fichier `go.mod` à la racine de votre site. Vous pouvez vérifi
 
 ### 5. Ajouter le thème en tant que module
 
-Maintenant, ajoutez la section `module` suivante dans votre fichier `config.yaml`. Cela ajoutera le thème comme un module et montera aussi les fichiers statiques à partir du thème.
+Maintenant, ajoutez la section `module` suivante dans votre fichier `hugo.yaml`. Cela ajoutera le thème comme un module et montera aussi les fichiers statiques à partir du thème.
 
 ```yaml
 # Utilise les modules Hugo pour ajouter le thème
@@ -73,13 +73,13 @@ module:
     target: static/fonts
 ```
 
-### 6. Actualiser le fichier `config.yaml`
+### 6. Actualiser le fichier `hugo.yaml`
 
-Dans la nouvelle version, la structure de configuration pour la gestion des fonctionnalités a été refondue. Donc, il est nécessaire d'actualiser le fichier `config.yaml` . Pour référence, vous pouvez vérifier l'extrait du [config.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/config.yaml). Ici, nous mettrons en évidence les configurations les plus couramment utilisées qui ont besoin d'être changé.
+Dans la nouvelle version, la structure de configuration pour la gestion des fonctionnalités a été refondue. Donc, il est nécessaire d'actualiser le fichier `hugo.yaml` . Pour référence, vous pouvez vérifier l'extrait du [hugo.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/hugo.yaml). Ici, nous mettrons en évidence les configurations les plus couramment utilisées qui ont besoin d'être changé.
 
 **Mode sombre:**
 
-Nous avons introduit un nouveau support intégré du mode sombre. En conséquence, il n'est plus nécessaire d'utiliser un service tiers tel que `darkreader`. Pour activer le nouveau mode sombre, s'il vous plaît supprimez les lignes suivantes de votre `config.yaml`.
+Nous avons introduit un nouveau support intégré du mode sombre. En conséquence, il n'est plus nécessaire d'utiliser un service tiers tel que `darkreader`. Pour activer le nouveau mode sombre, s'il vous plaît supprimez les lignes suivantes de votre `hugo.yaml`.
 
 ```yaml
  darkMode:

--- a/content/posts/update-v3-to-v4/index.md
+++ b/content/posts/update-v3-to-v4/index.md
@@ -22,9 +22,9 @@ git rm themes/toha/
 git commit -m "Remove v3 theme"
 ```
 
-### 2. Remove `theme` from `config.yaml`
+### 2. Remove `theme` from `hugo.yaml`
 
-In the new version, we no longer need to specify the `theme` in the `config.yaml` file. Instead, we will add the theme as a module. Therefore, remove the following line from your `config.yaml` file:
+In the new version, we no longer need to specify the `theme` in the `hugo.yaml` file. Instead, we will add the theme as a module. Therefore, remove the following line from your `hugo.yaml` file:
 
 ```yaml
 theme: toha
@@ -52,7 +52,7 @@ This will create a `go.mod` file in the root of your site. You can check the fil
 
 ### 5. Add the theme as a module
 
-Now, add the following `module` section in your `config.yaml` file. This will add the theme as a module and also mount the static files from the theme.
+Now, add the following `module` section in your `hugo.yaml` file. This will add the theme as a module and also mount the static files from the theme.
 
 ```yaml
 # Use Hugo modules to add theme
@@ -70,13 +70,13 @@ module:
     target: static/fonts
 ```
 
-### 6. Update the `config.yaml` file
+### 6. Update the `hugo.yaml` file
 
-In the new version, the configuration structure for managing features has been restructured. Therefore, it is necessary to update the `config.yaml` file. For reference, you can check the sample [config.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/config.yaml). Here, we will highlight the most commonly used configurations that need to be changed.
+In the new version, the configuration structure for managing features has been restructured. Therefore, it is necessary to update the `hugo.yaml` file. For reference, you can check the sample [hugo.yaml](https://github.com/hugo-toha/hugo-toha.github.io/blob/main/hugo.yaml). Here, we will highlight the most commonly used configurations that need to be changed.
 
 **Dark Mode:**
 
-We have introduced a new built-in dark mode support. As a result, there is no longer a need to use a third-party service like `darkreader`. To enable the new dark mode, please remove the following lines from your `config.yaml` file:
+We have introduced a new built-in dark mode support. As a result, there is no longer a need to use a third-party service like `darkreader`. To enable the new dark mode, please remove the following lines from your `hugo.yaml` file:
 
 ```yaml
  darkMode:

--- a/content/posts/writing-posts/math/index.es.md
+++ b/content/posts/writing-posts/math/index.es.md
@@ -27,7 +27,7 @@ En este ejemplo usaremos [KaTeX](https://katex.org/)
 {{ partial "math.html" . }}
 {{ end }}
 ```  
-- Para habilitar Katex globalmente establece el parámetro `math` a `true` en la configuración del proyecto en el archivo `config.yaml`.
+- Para habilitar Katex globalmente establece el parámetro `math` a `true` en la configuración del proyecto en el archivo `hugo.yaml`.
 - Para habilitar Katex en publicaciones concretas, incluye el parámetro `math: true` en los archivos de contenido correspondientes.
 
 **Nota:** Usa la referencia online de [Supported TeX Functions](https://katex.org/docs/supported.html)

--- a/content/posts/writing-posts/organizing/category/index.es.md
+++ b/content/posts/writing-posts/organizing/category/index.es.md
@@ -99,7 +99,7 @@ La siguiente imagen muestra cómo el contenido está distribuido en la sección 
 
 ## Personalizando la información del auto de la publicación
 
-Por defecto, la publicación usa la información de autor del archivo `config.yaml`. Si quieres sobrescribir la información predeterminada, simplemente añade la siguiente sección en el front-matter:
+Por defecto, la publicación usa la información de autor del archivo `hugo.yaml`. Si quieres sobrescribir la información predeterminada, simplemente añade la siguiente sección en el front-matter:
 
 ```yaml
 author:

--- a/content/posts/writing-posts/organizing/category/index.md
+++ b/content/posts/writing-posts/organizing/category/index.md
@@ -94,7 +94,7 @@ The following image shows how the contents are mapped into the sidebar section. 
 
 ## Customizing post's author information
 
-By default, the post should use author information from `config.yaml`. If you want to overwrite the default author information, just add following author section in the front-matter:
+By default, the post should use author information from `hugo.yaml`. If you want to overwrite the default author information, just add following author section in the front-matter:
 
 ```yaml
 author:

--- a/content/posts/writing-posts/using-emoji/index.es.md
+++ b/content/posts/writing-posts/using-emoji/index.es.md
@@ -16,7 +16,7 @@ Los emojis se pueden habilitar a un proyecto de Hugo de distintas formas.
 <!--more-->
 La función [`emojify`](https://gohugo.io/functions/emojify/) se puede llamar directamente a las plantillas o a los [Inline Shortcodes](https://gohugo.io/templates/shortcode-templates/#inline-shortcodes).
 
-Para habilitar los emojis globalmente, establece `enableEmoji` a `true` en el archivo `config.yaml` y después puedes escribir los códigos de los emojis directamente en archivos de contenido; por ejemplo. Más información [aquí](https://gohugo.io/getting-started/configuration/).
+Para habilitar los emojis globalmente, establece `enableEmoji` a `true` en el archivo `hugo.yaml` y después puedes escribir los códigos de los emojis directamente en archivos de contenido; por ejemplo. Más información [aquí](https://gohugo.io/getting-started/configuration/).
 
 
 <p><span class="nowrap"><span class="emojify">🙈</span> <code>:see_no_evil:</code></span>  <span class="nowrap"><span class="emojify">🙉</span> <code>:hear_no_evil:</code></span>  <span class="nowrap"><span class="emojify">🙊</span> <code>:speak_no_evil:</code></span></p>

--- a/data/en/site.yaml
+++ b/data/en/site.yaml
@@ -1,7 +1,7 @@
 # Copyright Notice
 copyright: © 2020 Copyright.
 
-# A disclaimer notice for the footer. Make sure you have set "params.footer.disclaimer.enable: true" in your `config.yaml` file.
+# A disclaimer notice for the footer. Make sure you have set "params.footer.disclaimer.enable: true" in your `hugo.yaml` file.
 disclaimer: "This theme is under MIT license. So, you can use it for non-commercial, commercial, or private uses.
 You can modify or distribute the theme without requiring any permission from the theme author.
 However, the theme author does not provide any warranty or takes any liability for any issue with the theme."
@@ -17,7 +17,7 @@ customMenus:
   # specify whether to hide the menu item from top navbar or not.
   hideFromNavbar: false
   # specify whether to show the menu item in footer or not.
-  # if you set it to true, make sure you have set `footer.navigation.customMenus: true` in your config.yaml
+  # if you set it to true, make sure you have set `footer.navigation.customMenus: true` in your hugo.yaml
   showOnFooter: false
 
 # Specify OpenGraph Headers

--- a/data/es/site.yaml
+++ b/data/es/site.yaml
@@ -1,7 +1,7 @@
 # Nota de copyright
 copyright: © 2020 Copyright.
 
-# Un aviso de exención de responsabilidad para el pie de página. Asegúrese de haber configurado "params.footer.disclaimer.enable: true" en su archivo `config.yaml`.
+# Un aviso de exención de responsabilidad para el pie de página. Asegúrese de haber configurado "params.footer.disclaimer.enable: true" en su archivo `hugo.yaml`.
 disclaimer: "Este tema está bajo licencia MIT. Por lo tanto, puede utilizarlo para usos no comerciales, comerciales o privados.
 Puede modificar o distribuir el tema sin requerir ningún permiso del autor del tema.
 Sin embargo, el autor del tema no ofrece ninguna garantía ni asume ninguna responsabilidad por cualquier problema con el tema."
@@ -17,7 +17,7 @@ customMenus:
   # especifica si quieres esconder el elemento de la barra de navegación o no.
   hideFromNavbar: false
   # especifica si quieres mostrar el elemento en el pie de página o no.
-  # si está configurado a true, assegúrase que tienes `footer.navigation.customMenus: true` en tu archivo config.yaml
+  # si está configurado a true, assegúrase que tienes `footer.navigation.customMenus: true` en tu archivo hugo.yaml
   showOnFooter: false
 
 # Especificar el encabezado OpenGraph

--- a/data/fr/site.yaml
+++ b/data/fr/site.yaml
@@ -1,7 +1,7 @@
 # Copyright Notice
 copyright: © 2020 Copyright.
 
-# A disclaimer notice for the footer. Make sure you have set "params.footer.disclaimer.enable: true" in your `config.yaml` file.
+# A disclaimer notice for the footer. Make sure you have set "params.footer.disclaimer.enable: true" in your `hugo.yaml` file.
 disclaimer: "Ce thème est sous licence MIT. Donc, vous pouvez l'utiliser pour des usages non-commercial, commercial, ou privé. Vous pouvez modifier ou distribuer ce thème qui ne requiert pas de permissions de l'auteur du thème. Cependant, l'auteur du thème ne fournit aucune garantie ou n'assume de responsabilité pour tout problème avec ce thème."
 
 # Meta description for your site.  This will help the search engines to find your site.
@@ -15,7 +15,7 @@ customMenus:
   # specify whether to hide the menu item from top navbar or not.
   hideFromNavbar: false
   # specify whether to show the menu item in footer or not.
-  # if you set it to true, make sure you have set `footer.navigation.customMenus: true` in your config.yaml
+  # if you set it to true, make sure you have set `footer.navigation.customMenus: true` in your hugo.yaml
   showOnFooter: false
 
 # Specify OpenGraph Headers


### PR DESCRIPTION
After renaming `config.yaml` file into `hugo.yaml` in https://github.com/hugo-toha/hugo-toha.github.io/commit/bb359184f59e0ff346305fdc21b15b18ec9686fb, I've replaced all these occurrences in order to keep the consistency.
- Fixes #301